### PR TITLE
ui: Support fixed content in `HazeScaffold` and `BasePage`

### DIFF
--- a/src/main/kotlin/dev/lackluster/hyperx/compose/base/BasePage.kt
+++ b/src/main/kotlin/dev/lackluster/hyperx/compose/base/BasePage.kt
@@ -74,6 +74,7 @@ fun BasePage(
         }
     },
     actions: @Composable RowScope.(padding: PaddingValues) -> Unit = {},
+    fixedContent: (@Composable () -> Unit)? = null,
     content: LazyListScope.() -> Unit
 ) {
     val topAppBarBackground = MiuixTheme.colorScheme.background
@@ -86,10 +87,12 @@ fun BasePage(
                     (listState.isScrollInProgress || listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > 12)
         }
     }
-    val topBarBlurTintAlpha = remember { mutableFloatStateOf(
-        if (topAppBarBackground.luminance() >= 0.5f) blurTintAlphaLight.floatValue
-        else blurTintAlphaDark.floatValue
-    ) }
+    val topBarBlurTintAlpha = remember {
+        mutableFloatStateOf(
+            if (topAppBarBackground.luminance() >= 0.5f) blurTintAlphaLight.floatValue
+            else blurTintAlphaDark.floatValue
+        )
+    }
     val layoutDirection = LocalLayoutDirection.current
     val systemBarInsets = WindowInsets.systemBars.add(WindowInsets.displayCutout).only(WindowInsetsSides.Horizontal).asPaddingValues()
     val navigationIconPadding = PaddingValues.Absolute(
@@ -124,6 +127,10 @@ fun BasePage(
             )
         ),
         adjustPadding = adjustPadding,
+        fixedBackgroundColor = topAppBarBackground.copy(
+            if (topBarBlurState) 0f else 1f
+        ),
+        fixedContent = fixedContent
     ) { paddingValues ->
         LazyColumn(
             modifier = Modifier

--- a/src/main/kotlin/dev/lackluster/hyperx/compose/base/HazeScaffold.kt
+++ b/src/main/kotlin/dev/lackluster/hyperx/compose/base/HazeScaffold.kt
@@ -1,16 +1,23 @@
 package dev.lackluster.hyperx.compose.base
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
@@ -43,8 +50,17 @@ fun HazeScaffold(
         ),
     ),
     adjustPadding: PaddingValues = PaddingValues(0.dp),
+    fixedBackgroundColor: Color = containerColor,
+    fixedContent: (@Composable () -> Unit)? = null,
     content: @Composable (PaddingValues) -> Unit
 ) {
+    val density = LocalDensity.current
+
+    var fixedContentHeightPx by remember { mutableIntStateOf(0) }
+    val fixedPadding = with(density) {
+        fixedContentHeightPx.toDp()
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = @Composable {
@@ -83,16 +99,38 @@ fun HazeScaffold(
         Box(
             Modifier.hazeSource(state = hazeState)
         ) {
-            content(PaddingValues(
-                start = contentPadding.calculateLeftPadding(LayoutDirection.Ltr) +
-                        adjustPadding.calculateLeftPadding(LayoutDirection.Ltr),
-                top = contentPadding.calculateTopPadding() +
-                        adjustPadding.calculateTopPadding(),
-                end = contentPadding.calculateRightPadding(LayoutDirection.Ltr) +
-                        adjustPadding.calculateRightPadding(LayoutDirection.Ltr),
-                bottom = contentPadding.calculateBottomPadding() +
-                        adjustPadding.calculateBottomPadding()
-            ))
+            content(
+                PaddingValues(
+                    start = contentPadding.calculateLeftPadding(LayoutDirection.Ltr) +
+                            adjustPadding.calculateLeftPadding(LayoutDirection.Ltr),
+                    top = contentPadding.calculateTopPadding() +
+                            adjustPadding.calculateTopPadding() +
+                            fixedPadding,
+                    end = contentPadding.calculateRightPadding(LayoutDirection.Ltr) +
+                            adjustPadding.calculateRightPadding(LayoutDirection.Ltr),
+                    bottom = contentPadding.calculateBottomPadding() +
+                            adjustPadding.calculateBottomPadding()
+                )
+            )
+        }
+
+        fixedContent?.let {
+            Box(
+                modifier = if (blurTopBar) {
+                    Modifier.hazeEffect(state = hazeState, style = hazeStyle)
+                } else {
+                    Modifier
+                }
+                    .background(fixedBackgroundColor)
+                    .padding(top = contentPadding.calculateTopPadding())
+                    .onSizeChanged { size ->
+                        if (fixedContentHeightPx != size.height) {
+                            fixedContentHeightPx = size.height
+                        }
+                    }
+            ) {
+                it()
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/lackluster/hyperx/compose/base/HazeScaffold.kt
+++ b/src/main/kotlin/dev/lackluster/hyperx/compose/base/HazeScaffold.kt
@@ -1,6 +1,8 @@
 package dev.lackluster.hyperx.compose.base
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -20,6 +22,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
@@ -121,8 +124,13 @@ fun HazeScaffold(
                 } else {
                     Modifier
                 }
+                    .zIndex(1f)
                     .background(fixedBackgroundColor)
                     .padding(top = contentPadding.calculateTopPadding())
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ) {} // Prevent penetration clicks
                     .onSizeChanged { size ->
                         if (fixedContentHeightPx != size.height) {
                             fixedContentHeightPx = size.height


### PR DESCRIPTION
- Add `fixedContent` parameter to `HazeScaffold` and `BasePage` to allow UI elements to remain pinned below the top bar while scrolling.
- Automatically adjust content padding based on the measured height of the fixed content.
- Update `MediaControlPage` and `IconDetailPage` to use the new `fixedContent` slot for header cards.
- Adjust vertical padding for `MediaControlCard` and detail page cards.